### PR TITLE
Add config file for setting typescript compiler configurations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
     "compilerOptions": {
-        "baseUrl": ".",
         "allowJs": true
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "allowJs": true
+    }
+}


### PR DESCRIPTION
The project contains both javascript and typescript files. We need to add a configuration file - tsconfig.json to add various configuration options, otherwise we won't be able to import javascript files. We need to compile both javascript and typescript files.
By setting "allowJS" option to be true, we can import javascript files as well.